### PR TITLE
No rdflib predefined namespaces, datatypes for all values and QUDT units

### DIFF
--- a/pylindas/pycube/cube.py
+++ b/pylindas/pycube/cube.py
@@ -203,7 +203,7 @@ class Cube:
         Returns:
             Graph: The graph object with namespaces bound.
         """
-        graph = Graph()
+        graph = Graph(bind_namespaces="none")
         for prefix, nmspc in Namespaces.items():
             graph.bind(prefix=prefix, namespace=nmspc)
         try:

--- a/pylindas/pycube/cube.py
+++ b/pylindas/pycube/cube.py
@@ -449,14 +449,11 @@ class Cube:
             case _ as unrecognized:
                 print(f"Scale Type '{unrecognized}' is not recognized")
         
-        try:
-            match dim_dict.get("unit"):
-                case "kilogramm":
-                   self._graph.add((dim_node, QUDT.hasUnit, UNIT.KiloGM))
-                case "percent":
-                   self._graph.add((dim_node, QUDT.hasUnit, UNIT.PERCENT))
-        except KeyError:
-            pass
+        
+        # unit from https://www.qudt.org/doc/DOC_VOCAB-UNITS.html
+
+        if dim_dict.get("unit") != None:
+            self._graph.add((dim_node, QUDT.hasUnit, getattr(UNIT, dim_dict.get("unit"))))
 
         try:
             data_kind = dim_dict.get("data-kind")

--- a/pylindas/pycube/cube.py
+++ b/pylindas/pycube/cube.py
@@ -303,7 +303,6 @@ class Cube:
         """Write observations to the cube.
 
         This function iterates over the rows in the dataframe and adds each row as an observation to the cube.
-        It also adds the observation URI to the observation set of the cube.
 
         Returns:
             Self
@@ -328,6 +327,8 @@ class Cube:
 
     def _add_observation(self, obs: pd.DataFrame) -> None:
         """Add an observation to the cube.
+
+        It also adds the observation URI to the observation set of the cube.
         
             Args:
                 obs (pd.DataFrame): The observation data to be added.

--- a/pylindas/pycube/cube.py
+++ b/pylindas/pycube/cube.py
@@ -571,7 +571,10 @@ class Cube:
         elif lang!=None:
             return Literal(value, lang=lang)
         else:
-            return Literal(value, datatype=getattr(XSD, datatype))
+            if datatype != None:
+                return Literal(value, datatype=getattr(XSD, datatype))
+            else:
+                return Literal(value)
 
 
 

--- a/pylindas/pycube/cube.py
+++ b/pylindas/pycube/cube.py
@@ -325,18 +325,18 @@ class Cube:
         self._graph.serialize(destination=filename, format="turtle", encoding="utf-8")
         return self
 
-    def _add_observation(self, obs: pd.DataFrame) -> None:
+    def _add_observation(self, obs: pd.Series) -> None:
         """Add an observation to the cube.
 
         It also adds the observation URI to the observation set of the cube.
         
             Args:
-                obs (pd.DataFrame): The observation data to be added.
+                obs (pd.Series): The observation data to be added. These are the single rows from the _dataframe.
         
             Returns:
                 None
         """
-        self._graph.add((self._cube_uri + "/ObservationSet", CUBE.observation, obs.name))
+        self._graph.add((self._cube_uri + "/ObservationSet", CUBE.observation, obs.name)) #obs.name is the index of the row which was set to be the 'obs-uri'
         self._graph.add((obs.name, RDF.type, CUBE.Observation))
         self._graph.add((obs.name, CUBE.observedBy, URIRef(self._cube_dict.get("Creator")[0].get("IRI"))))
 


### PR DESCRIPTION
In getting used to the codebase of the fantastic *pylindas*, I tried to do some changes that maybe are helpful (and if not, just ignore them completely) for the community - maybe I also have misinterpreted oder missunderstood some general structures of pylindas. The proposed changes:

- no use of rdflib predefined namespaces (otherwise, there will be a `schema1` prefix because `schema` is reserved for http**s**://schema.org
- datatypes for every value of the observation if needed (like xsd:gYear, ...)
- language tags for string values of observation
- possibility to use QUDT units directly (I'm aware of #17 but think the users could get used to the QUDT units because complicated values would have to be looked up in every case, e.g. Cubic Centimeter per Mole Second ;-) 