### PR TITLE
Rewrite this "except" expression as a tuple of exception classes.

### DIFF
--- a/pylindas/pycube/cube.py
+++ b/pylindas/pycube/cube.py
@@ -5,7 +5,7 @@ from rdflib.collection import Collection
 from datetime import datetime, timezone
 try:
     from typing import Self
-except:
+except ImportError:
     # fallback for Self in python 3.10
     from typing import TypeVar
     Self = TypeVar("Self", bound="Cube")
@@ -717,7 +717,7 @@ class Cube:
                         self._graph.add((dim_node, META.dataKind, data_kind_node))
             except AttributeError:
                 pass
-        except KeyError or AttributeError:
+        except (KeyError, AttributeError):
             pass
         
         if dim_dict.get("annotation"):

--- a/pylindas/pyshareddimension/shared_dimension.py
+++ b/pylindas/pyshareddimension/shared_dimension.py
@@ -5,7 +5,7 @@ from rdflib.collection import Collection
 from datetime import datetime, timezone
 try:
     from typing import Self
-except:
+except ImportError:
     # fallback for Self in python 3.10
     from typing import TypeVar
     Self = TypeVar("Self", bound="SharedDimension")


### PR DESCRIPTION
Added the exact exception to catch for python 3.10 imports.


From Sonarcloud.io for tuples:

The only two possible types for an except's expression are a class deriving from BaseException, or a tuple composed of such classes.

Trying to catch multiple exception in the same except with a boolean expression of exceptions may not work as intended. The result of a boolean expression of exceptions is a single exception class, thus using a boolean expression in an except block will result in catching only one kind of exception.