### PR TITLE
adding new optional keyowrd Base to Shared Dimensions

### DIFF
--- a/example/Shared_Dimensions/shared_dimension_generation/sd_description.yml
+++ b/example/Shared_Dimensions/shared_dimension_generation/sd_description.yml
@@ -2,6 +2,7 @@
 # If the SD URL starts with http, it will instead use that instead of the default
 # Note: a SD's URL is not relative to the LINDAS environment, and it will be dereferenceable only when published on PROD
 Identifier: pylindas_sd_generation_example
+# TODO Base: Optional, allows for separation of DefinedTermSet and the base for identifier-field, where identifier defines the TermSet
 Name:
   en: PyLindas Shared Dimension generation example
   fr: PyLindas example de génération d'une Shared Dimension 

--- a/pylindas/pyshareddimension/shared_dimension.py
+++ b/pylindas/pyshareddimension/shared_dimension.py
@@ -15,7 +15,7 @@ import sys
 
 from pylindas.lindas.namespaces import *
 from pylindas.lindas.query import query_lindas
-from pyshacl import validate
+from pyshacl import validate, errors
 
 class SharedDimension:
     _sd_uri: URIRef # Note: Shared Dimension usually do not have a trailing "/" in there URL
@@ -172,11 +172,15 @@ class SharedDimension:
             None
         """
         termIdentifierField = self._sd_dict.get("Terms").get("identifier-field")
-
+        base = self._sd_dict.get("Base")
         # Note: Shared Dimension usually do not have a trailing "/" in there URL
         #   -> add it 
         def make_iri(row):
-            return self._sd_uri + "/" + quote(str(row[termIdentifierField]))
+            # allows for a different DefinedTermSet URI, only if base is declared
+            if base:
+                return base + "/" + quote(str(row[termIdentifierField]))
+            else:
+                return self._sd_uri + "/" + quote(str(row[termIdentifierField]))
         self._dataframe['terms-uri'] = self._dataframe.apply(
             make_iri, axis=1
         )
@@ -454,4 +458,4 @@ class SharedDimension:
         if valid_sd:
             return True, "Shared dimension basics are met."
         else:
-            return False, text_sd
+            raise ValueError(text_sd)


### PR DESCRIPTION
Added optional keyword Base to Shared Dimensions, such that DefinedTermSets, and URI of the Term, are not necessarily related,
added as an optional addition, such that it is not used unintentionally.

Also no Raises a ValueError, if shareddimension is Invalid

